### PR TITLE
 Use a different content ID for taxon removal test

### DIFF
--- a/spec/integration/govuk_index/taxon_spec.rb
+++ b/spec/integration/govuk_index/taxon_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "taxon publishing" do
 
   it "removes a taxon page" do
     allow(GovukIndex::MigratedFormats).to receive(:indexable_formats).and_return("taxon" => :all)
-    content_id = "b7e993e1-9afa-4235-99a4-479caa240267"
+    content_id = "c6d82aef-8f85-43b5-8a15-87719916204c"
     document = { "link" => "/transport/all", "content_id" => content_id }
 
     commit_document('govuk_test', document, id: content_id, type: 'taxon')

--- a/spec/support/integration_spec_helper.rb
+++ b/spec/support/integration_spec_helper.rb
@@ -107,8 +107,7 @@ module IntegrationSpecHelper
   end
 
   def commit_document(index_name, attributes, id: attributes["link"], type: "edition")
-    attributes['document_type'] ||= type
-    return_id = insert_document(index_name, attributes, id: id, type: 'generic-document')
+    return_id = insert_document(index_name, attributes, id: id, type: type)
     commit_index(index_name)
     return_id
   end


### PR DESCRIPTION
This same content ID is used in the external content tests.  We use the content ID as the document ID in these integration tests (normally we use the base path).  As we're now using a single mapping type, this means the document identifiers collide.

We use versioning to ensure that a document in elasticsearch hasn't changed while we attempt to delete it.  I assume inserting a second document with the same ID is altering the version number, and so causing the delete to fail.

I don't think this problem can arise during normal execution, as it requires two documents to have the same ID, and the publishing-api prevents that by ensuring that both base paths and content IDs are unique.

---

[Trello card](https://trello.com/c/RIKZlw0k/66-fix-flakey-search-api-integration-test)