### PR TITLE
Do not use "must" with "should" or "filter"

### DIFF
--- a/lib/analytics_data.rb
+++ b/lib/analytics_data.rb
@@ -15,9 +15,9 @@ class AnalyticsData
       query: {
         bool: {
           must: { match_all: {} },
-          filter: Search::FormatMigrator.new.call,
         },
       },
+      post_filter: Search::FormatMigrator.new.call,
     }
 
     ScrollEnumerator.new(client: client, index_names: @indices, search_body: query) do |hit|

--- a/lib/duplicate_links_finder.rb
+++ b/lib/duplicate_links_finder.rb
@@ -11,7 +11,6 @@ class DuplicateLinksFinder
       query: {
         bool: {
           must: { match_all: {} },
-          filter: Search::FormatMigrator.new.call,
         },
       },
       aggs: {
@@ -29,6 +28,7 @@ class DuplicateLinksFinder
           }
         }
       },
+      post_filter: Search::FormatMigrator.new.call,
       size: 0,
     }
     results = client.search(index: indices, body: body)

--- a/lib/indexer/comparer.rb
+++ b/lib/indexer/comparer.rb
@@ -21,12 +21,7 @@ module Indexer
 
       search_body = {}
       if @filtered_format
-        search_body[:query] = {
-          bool: {
-            must: { match_all: {} },
-            filter: { term: { format: @filtered_format } }
-          }
-        }
+        search_body[:post_filter] = { term: { format: @filtered_format } } if @filtered_format
       end
 
       CompareEnumerator.new(@old_index_name, @new_index_name, search_body, @enum_options).each do |old_item, new_item|

--- a/lib/legacy_search/advanced_search_query_builder.rb
+++ b/lib/legacy_search/advanced_search_query_builder.rb
@@ -77,10 +77,14 @@ module LegacySearch
       {
         query: {
           bool: {
-            filter: filter_array,
             must: keyword_query_hash
           }
-        }
+        },
+        post_filter: {
+          bool: {
+            must: filter_array
+          }
+        },
       }.merge(order_query_hash)
     end
 

--- a/lib/search/aggregate_example_fetcher.rb
+++ b/lib/search/aggregate_example_fetcher.rb
@@ -70,9 +70,9 @@ module Search
           query: {
             bool: {
               must: query,
-              filter: { bool: { must: filter } },
             }
           },
+          post_filter: { bool: { must: filter } },
           size: example_count,
           _source: {
             includes: example_fields,

--- a/lib/search/best_bets_checker.rb
+++ b/lib/search/best_bets_checker.rb
@@ -120,14 +120,14 @@ module Search
       {
         query: {
           bool: {
-            must: {
-              match: { document_type: "best_bet" },
-            },
             should: [
               { match: { exact_query: @query } },
-              { match: { stemmed_query: @query } }
+              { match: { stemmed_query: @query } },
             ]
           }
+        },
+        post_filter: {
+          bool: { must: { match: { document_type: "best_bet" } } }
         },
         size: 1000,
         _source: {

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -15,9 +15,9 @@ class SitemapGenerator
       query: {
         bool: {
           must_not: { terms: { format: EXCLUDED_FORMATS } },
-          filter: Search::FormatMigrator.new.call,
         }
       },
+      post_filter: Search::FormatMigrator.new.call,
     }
     property_boost_calculator = PropertyBoostCalculator.new
 

--- a/spec/integration/comparer_spec.rb
+++ b/spec/integration/comparer_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe 'ComparerTest' do
       query: {
         bool: {
           must: { match_all: {} },
-          filter: { term: { format: 'edition' } }
         }
-      }
+      },
+      post_filter: { term: { format: 'edition' } }
     }
     results = Indexer::CompareEnumerator.new('govuk_test', 'government_test', query)
 

--- a/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
+++ b/spec/unit/legacy_search/elasticsearch_index_advanced_search_spec.rb
@@ -28,9 +28,13 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
     stub_empty_search(body: {
       "from" => 0,
       "size" => 1,
+      "post_filter" => {
+        "bool" => {
+          "must" => [{ "bool" => { "must_not" => { "term" => { "is_withdrawn" => true } } } }]
+        }
+      },
       "query" => {
         "bool" => {
-          "filter" => [{ "bool" => { "must_not" => { "term" => { "is_withdrawn" => true } } } }],
           "must" => {
             "function_score" => {
               "query" => {
@@ -97,7 +101,7 @@ RSpec.describe SearchIndices::Index, 'Advanced Search' do
   end
 
   it "filter params are turned into anded term filters on that property" do
-    stub_empty_search(body: /#{Regexp.escape("\"filter\":[{\"term\":{\"mainstream_browse_pages\":\"jones\"}},{\"term\":{\"link\":\"richards\"}},")}/)
+    stub_empty_search(body: /#{Regexp.escape("[{\"term\":{\"mainstream_browse_pages\":\"jones\"}},{\"term\":{\"link\":\"richards\"}},")}/)
     @wrapper.advanced_search(default_params.merge('mainstream_browse_pages' => ['jones'], 'link' => ['richards']))
   end
 

--- a/spec/unit/search/aggregate_example_fetcher_spec.rb
+++ b/spec/unit/search/aggregate_example_fetcher_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe Search::AggregateExampleFetcher do
       query: {
         bool: {
           must: nil,
-          filter: {
-            bool: {
-              must: [
-                { term: { field => value } },
-                { indices: {
-                    indices: SearchConfig.instance.content_index_names,
-                    query: { bool: { must: { match_all: {} } } },
-                    no_match_query: 'none'
-                  } }
-              ]
-            },
-          },
+        },
+      },
+      post_filter: {
+        bool: {
+          must: [
+            { term: { field => value } },
+            { indices: {
+                indices: SearchConfig.instance.content_index_names,
+                query: { bool: { must: { match_all: {} } } },
+                no_match_query: 'none'
+              } }
+          ]
         },
       },
       size: 2,
@@ -33,14 +33,14 @@ RSpec.describe Search::AggregateExampleFetcher do
       query: {
         bool: {
           must: query,
-          filter: {
-            bool: {
-              must: [
-                { term: { field => value } },
-                filter
-              ]
-            }
-          }
+        }
+      },
+      post_filter: {
+        bool: {
+          must: [
+            { term: { field => value } },
+            filter
+          ]
         }
       },
       size: 2,

--- a/spec/unit/search/best_bets_checker_spec.rb
+++ b/spec/unit/search/best_bets_checker_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Search::BestBetsChecker do
     {
       query: {
         bool: {
-          must: {
-            match: { document_type: "best_bet" },
-          },
           should: [
             { match: { exact_query: query } },
-            { match: { stemmed_query: query } }
+            { match: { stemmed_query: query } },
           ]
         }
+      },
+      post_filter: {
+        bool: { must: { match: { document_type: "best_bet" } } }
       },
       size: 1000,
       _source: { includes: %i[details stemmed_query_as_term] },


### PR DESCRIPTION
A matching "must" overrides a failing "should" and "filter":

> If the `bool` query is in a query context and has a `must` or `filter` clause then a document will match the `bool` query even if none of the `should` queries match. In this case these clauses are only used to influence the score.

So this PR makes two changes:

1. Fix the one case where we have a `must` / `should` pair (best bets)
2. Turn all the cases where we have a `must` / `filter` pair into a `query` with a `must` + a `post_filter`, which is closer to how a lot of these things were before I changed the queries in the first place.

This touches a few different aspects of search, so we do some more manual testing.

---

[Trello card](https://trello.com/c/DrGWIXbo/85-best-bets-are-broken)