### PR TITLE
Remove document type from result metadata

### DIFF
--- a/config/finders/policy_and_engagement.yml
+++ b/config/finders/policy_and_engagement.yml
@@ -42,7 +42,7 @@ details:
     name: Document type
     preposition: with document type
     type: text
-    display_as_result_metadata: true
+    display_as_result_metadata: false
     filterable: true
     option_lookup:
       policy_papers:


### PR DESCRIPTION
This PR removes document type on search result metadata.

Trello: https://trello.com/c/BaGKQ3FM/520-remove-doc-type-metadata-from-results-in-policy-papers-and-consultations-finder