### PR TITLE
Implement index locking with Redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "plek", "~> 2.1"
 gem "rack", "~> 2.0"
 gem "rack-logstasher", "~> 1.0.0"
 gem "rake", "~> 12.3"
+gem "redis", "~> 4.1.0"
 gem 'sidekiq-limit_fetch'
 gem "sinatra", "~> 2.0.5"
 gem "statsd-ruby", "~> 1.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ DEPENDENCIES
   rack-test (~> 1.1.0)
   rainbow
   rake (~> 12.3)
+  redis (~> 4.1.0)
   rspec
   sidekiq-limit_fetch
   simplecov (~> 0.16.1)

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -133,17 +133,11 @@ RSpec.describe 'ElasticsearchIndexingTest' do
     expect_document_is_in_rummager(SAMPLE_DOCUMENT, index: "government_test")
   end
 
+  # rubocop:disable RSpec/AnyInstance
   context "when indexing to the metasearch index" do
     it "reschedules the job if the index has a write lock" do
-      stubbed_client = client
-
-      locked_response = { "items" => [
-        { "index" => { "error" => { "reason" => "[FORBIDDEN/metasearch/index write" } } }
-      ] }
-
-      expect(stubbed_client).to receive(:bulk).and_return(locked_response)
-      expect(stubbed_client).to receive(:bulk).and_call_original
-      allow_any_instance_of(SearchIndices::Index).to receive(:build_client).and_return(stubbed_client)
+      allow_any_instance_of(SearchIndices::Index).to receive(:locked?).and_return(true)
+      allow_any_instance_of(SearchIndices::Index).to receive(:locked?).and_call_original
 
       details = <<~DETAILS
         {\"best_bets\":[
@@ -174,15 +168,8 @@ RSpec.describe 'ElasticsearchIndexingTest' do
 
   context "when indexing content" do
     it "reschedules the job if the index has a write lock" do
-      stubbed_client = client
-
-      locked_response = { "items" => [
-        { "index" => { "error" => { "reason" => "[FORBIDDEN/metasearch/index write" } } }
-      ] }
-
-      expect(stubbed_client).to receive(:bulk).and_return(locked_response)
-      expect(stubbed_client).to receive(:bulk).and_call_original
-      allow_any_instance_of(SearchIndices::Index).to receive(:build_client).and_return(stubbed_client)
+      allow_any_instance_of(SearchIndices::Index).to receive(:locked?).and_return(true)
+      allow_any_instance_of(SearchIndices::Index).to receive(:locked?).and_call_original
 
       publishing_api_has_expanded_links(
         content_id: "6b965b82-2e33-4587-a70c-60204cbb3e29",
@@ -224,4 +211,5 @@ RSpec.describe 'ElasticsearchIndexingTest' do
       )
     end
   end
+  # rubocop:enable RSpec/AnyInstance
 end


### PR DESCRIPTION
AWS managed ES doesn't support locking, but we need it to safely
implement schema migrations.

The schema migration process locks the old index, copies data to the
new index, compares the two indices, and then swaps the alias.
Without locking, the comparison step cannot be implemented reliably.

The comparison step is essential because, eg, if ES has a problem and
rejects writes to the new index, the comparison step is what will
catch that and prevent the new index from being activated.

This change does introduce a potential TOCTOU bug though:

1. Thread 1 checks if the index is locked, and gets "no"
2. Thread 2 locks the index and begins schema migration
3. Thread 1 writes to the index
4. Thread 2 finishes schema migration, finds a discrepancy between the
   indices, and throws an error.

To offset that problem, locking imposes a 2s delay, which should make
this far less likely.

---

[Trello card](https://trello.com/c/73ligyT2/88-aws-managed-elasticsearch-doesnt-support-index-locking-so-fix-code-which-relies-on-it)