### PR TITLE
Revert similarity metric and schema to ES2 versions

### DIFF
--- a/config/schema/elasticsearch_schema.yml
+++ b/config/schema/elasticsearch_schema.yml
@@ -1,5 +1,8 @@
 index:
   settings:
+    similarity:
+      default:
+        type: classic
     mapping:
       total_fields:
         limit: 2000

--- a/config/schema/field_types.json
+++ b/config/schema/field_types.json
@@ -3,8 +3,9 @@
     "description": "An identifier, can be used for exact (case and whitespace sensitive) lookup and aggregating",
     "filter_type": "text",
     "es_config": {
-      "type": "keyword",
-      "index": true
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false
     }
   },
 
@@ -13,8 +14,9 @@
     "filter_type": "text",
     "multivalued": true,
     "es_config": {
-      "type": "keyword",
-      "index": true
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": false
     }
   },
 
@@ -22,8 +24,9 @@
     "description": "Like an identifier, but should also be considered in non-field-specific text searches",
     "filter_type": "text",
     "es_config": {
-      "type": "keyword",
-      "index": true,
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": true,
       "copy_to": ["spelling_text", "all_searchable_text"]
     }
   },
@@ -33,8 +36,9 @@
     "filter_type": "text",
     "multivalued": true,
     "es_config": {
-      "type": "keyword",
-      "index": true,
+      "type": "string",
+      "index": "not_analyzed",
+      "include_in_all": true,
       "copy_to": ["spelling_text", "all_searchable_text"]
     }
   },
@@ -42,18 +46,21 @@
   "searchable_text": {
     "description": "A piece of plain text that should be split into words and considered in searches",
     "es_config": {
-      "type": "text",
-      "index": true,
+      "type": "string",
+      "index": "analyzed",
+      "include_in_all": true,
       "copy_to": ["spelling_text", "all_searchable_text"],
       "fields": {
         "no_stop": {
-          "type": "text",
-          "index": true,
+          "type": "string",
+          "index": "analyzed",
+          "include_in_all": false,
           "analyzer": "searchable_text"
         },
         "synonym": {
-          "type": "text",
-          "index": true,
+          "type": "string",
+          "index": "analyzed",
+          "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
         }
@@ -64,13 +71,15 @@
   "all_searchable_text_type": {
     "description": "A type for a special single field that all searchable text is copied into (using `copy_to` directives in elasticsearch). We use this instead of the built-in `_all` so that we can analyze it in multiple ways",
     "es_config": {
-      "type": "text",
-      "index": true,
+      "type": "string",
+      "index": "analyzed",
       "analyzer": "searchable_text",
+      "include_in_all": false,
       "fields": {
         "synonym": {
-          "type": "text",
-          "index": true,
+          "type": "string",
+          "index": "analyzed",
+          "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
         }
@@ -81,24 +90,28 @@
   "searchable_sortable_text": {
     "description": "A piece of plain text that should be split into words and considered in searches, but can also be sorted on",
     "es_config": {
-      "type": "text",
-      "index": true,
+      "type": "string",
+      "index": "analyzed",
+      "include_in_all": true,
       "copy_to": ["spelling_text"],
       "fields": {
         "sort": {
-          "type": "text",
-          "index": true,
+          "type": "string",
+          "index": "analyzed",
           "analyzer": "string_for_sorting",
+          "include_in_all": false,
           "fielddata": true
         },
         "no_stop": {
-          "type": "text",
-          "index": true,
+          "type": "string",
+          "index": "analyzed",
+          "include_in_all": false,
           "analyzer": "searchable_text"
         },
         "synonym": {
-          "type": "text",
-          "index": true,
+          "type": "string",
+          "index": "analyzed",
+          "include_in_all": false,
           "analyzer": "with_index_synonyms",
           "search_analyzer": "with_search_synonyms"
         }
@@ -109,25 +122,27 @@
   "unsearchable_text": {
     "description": "A piece of text which can be returned, but which is not searchable",
     "es_config": {
-      "type": "keyword",
-      "index": "false"
+      "type": "string",
+      "index": "no",
+      "include_in_all": false
     }
   },
 
   "spelling_text": {
     "description": "Text which is tokenised into words and lowercased, but not stemmed, stopworded, etc. This can be used for spelling correction, or exact word matching",
     "es_config": {
-      "type": "text",
-      "index": true,
-      "analyzer": "spelling_analyzer"
+      "type": "string",
+      "index": "analyzed",
+      "analyzer": "spelling_analyzer",
+      "include_in_all": false
     }
   },
 
   "best_bet_exact_match_text": {
     "description": "Type used in best-bets implementation for matching the whole stored query exactly (other than lowercasing and whitespace trimming)",
     "es_config": {
-      "type": "text",
-      "index": true,
+      "type": "string",
+      "index": "analyzed",
       "analyzer": "exact_match"
     }
   },
@@ -135,8 +150,8 @@
   "best_bet_stemmed_match_text": {
     "description": "Type used in best-bets implementation for matching the stored query with stemming and word splitting",
     "es_config": {
-      "type": "text",
-      "index": true,
+      "type": "string",
+      "index": "analyzed",
       "analyzer": "best_bet_stemmed_match"
     }
   },
@@ -152,7 +167,8 @@
   "boolean": {
     "description": "A boolean value which can be returned and used for filtering and aggregating",
     "es_config": {
-      "type": "boolean"
+      "type": "boolean",
+      "include_in_all": false
     }
   },
 
@@ -160,7 +176,8 @@
     "description": "A date which can be returned and used for ordering, filtering and aggregating",
     "filter_type": "date",
     "es_config": {
-      "type": "date"
+      "type": "date",
+      "include_in_all": false
     }
   },
 
@@ -171,7 +188,8 @@
     "es_config": {
       "type": "object",
       "enabled": "true",
-      "dynamic": "strict"
+      "dynamic": "strict",
+      "include_in_all": false
     }
   },
 
@@ -180,7 +198,8 @@
     "children": "dynamic",
     "es_config": {
       "type": "object",
-      "enabled": "false"
+      "enabled": "false",
+      "include_in_all": false
     }
   }
 }

--- a/spec/unit/schema/elasticsearch_types_parser_spec.rb
+++ b/spec/unit/schema/elasticsearch_types_parser_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ElasticsearchTypesParser do
     before do
       field_definitions = FieldDefinitionParser.new(schema_dir).parse
       @types = described_class.new(schema_dir, field_definitions).parse
-      @identifier_es_config = { "type" => "keyword", "index" => true }
+      @identifier_es_config = { "type" => "string", "index" => "not_analyzed", "include_in_all" => false }
     end
 
     it "recognise the `manual section` type" do

--- a/spec/unit/schema/index_schema_parser_spec.rb
+++ b/spec/unit/schema/index_schema_parser_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe IndexSchemaParser do
       field_definitions = FieldDefinitionParser.new(schema_dir).parse
       elasticsearch_types = ElasticsearchTypesParser.new(schema_dir, field_definitions).parse
       @index_schemas = described_class.parse_all(schema_dir, field_definitions, elasticsearch_types)
-      @identifier_es_config = { "type" => "keyword", "index" => true }
+      @identifier_es_config = { "type" => "string", "index" => "not_analyzed", "include_in_all" => false }
     end
 
     it "have a schema for the govuk index" do


### PR DESCRIPTION
We have a problem with search results being Weird.  These changes fix it.  We'll need to revisit this before moving to ES6 though.

---

[Trello card](https://trello.com/c/C3STgB2P/86-ordering-of-search-results-is-weird)