### PR TITLE
Change the index blocking method

### DIFF
--- a/lib/govuk_index/page_traffic_loader.rb
+++ b/lib/govuk_index/page_traffic_loader.rb
@@ -22,12 +22,14 @@ module GovukIndex
 
         GovukIndex::PageTrafficWorker.wait_until_processed
         new_index.commit
-
-        # Switch aliases inside the lock so we avoid a race condition where a
-        # new index exists, but the old index is available for writes
-        index_group.switch_to(new_index)
-        old_index.close
       end
+
+      # We need to switch the aliases without a lock, since
+      # read_only_allow_delete prevents aliases being changed
+      # The page traffic loader is is a daily process, so there
+      # won't be a race condition
+      index_group.switch_to(new_index)
+      old_index.close
     end
 
   private

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -58,13 +58,13 @@ module SearchIndices
 
     # Apply a write lock to this index, making it read-only
     def lock
-      request_body = { "index" => { "blocks" => { "write" => true } } }
+      request_body = { "index" => { "blocks" => { "read_only_allow_delete" => true } } }
       @client.indices.put_settings(index: @index_name, body: request_body)
     end
 
     # Remove any write lock applied to this index
     def unlock
-      request_body = { "index" => { "blocks" => { "write" => false } } }
+      request_body = { "index" => { "blocks" => { "read_only_allow_delete" => false } } }
       @client.indices.put_settings(index: @index_name, body: request_body)
     end
 
@@ -234,11 +234,11 @@ module SearchIndices
   private
 
     # Parse an elasticsearch error message to determine whether it's caused by
-    # a write-locked index. An example write-lock error message:
+    # a read-only index. An example read-only error message:
     #
-    #     "ClusterBlockException[blocked by: [FORBIDDEN/8/index write (api)];]"
+    #     "ClusterBlockException[blocked by: [FORBIDDEN/8/index read-only / allow delete (api)];]"
     def locked_index_error?(error_message)
-      error_message =~ %r{\[FORBIDDEN/[^/]+/index write}
+      error_message =~ %r{\[FORBIDDEN/[^/]+/index read-only}
     end
 
     def logger

--- a/spec/integration/indexer/indexing_spec.rb
+++ b/spec/integration/indexer/indexing_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'ElasticsearchIndexingTest' do
       stubbed_client = client
 
       locked_response = { "items" => [
-        { "index" => { "error" => { "reason" => "[FORBIDDEN/metasearch/index write" } } }
+        { "index" => { "error" => { "reason" => "[FORBIDDEN/metasearch/index read-only" } } }
       ] }
 
       expect(stubbed_client).to receive(:bulk).and_return(locked_response)
@@ -177,7 +177,7 @@ RSpec.describe 'ElasticsearchIndexingTest' do
       stubbed_client = client
 
       locked_response = { "items" => [
-        { "index" => { "error" => { "reason" => "[FORBIDDEN/metasearch/index write" } } }
+        { "index" => { "error" => { "reason" => "[FORBIDDEN/metasearch/index read-only" } } }
       ] }
 
       expect(stubbed_client).to receive(:bulk).and_return(locked_response)

--- a/spec/integration/schema_migrator_spec.rb
+++ b/spec/integration/schema_migrator_spec.rb
@@ -9,10 +9,9 @@ RSpec.describe SchemaMigrator do
     index_group = search_server.index_group("govuk_test")
     original_index = index_group.current_real
 
-    SchemaMigrator.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new) do |migrator|
-      migrator.reindex
-      migrator.switch_to_new_index
-    end
+    migrator = described_class.new("govuk_test", search_config, wait_between_task_list_check: 0.2, io: StringIO.new)
+    migrator.reindex
+    migrator.switch_to_new_index
 
     expect(index_group.current_real.real_name).not_to eq(original_index.real_name)
   end


### PR DESCRIPTION
AWS have a process that runs regularly and updates `index.blocks.write` based on the cluster health.  This resulted in the blocking being reset periodically.

After discussion with AWS, they proposed changing this setting to `index.blocks.read_only_allow_delete`, which is not reset by their processes.

Additionally, the locking needed updating since `index.blocks.read_only_allow_delete` does not permit alias updates, so the index must be unlocked before changing aliases.

Trello card: https://trello.com/c/73ligyT2/88-aws-managed-elasticsearch-doesnt-support-index-locking-so-fix-code-which-relies-on-it