### PR TITLE
Revert "Change Plek to use 'external: true' for publishing-api"

### DIFF
--- a/lib/publishing_api_finder_publisher.rb
+++ b/lib/publishing_api_finder_publisher.rb
@@ -17,7 +17,7 @@ private
 
   def publishing_api
     @publishing_api ||= GdsApi::PublishingApiV2.new(
-      Plek.new.find('publishing-api', external: true),
+      Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
       timeout: 10,
     )

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -3,7 +3,7 @@ require 'active_support/cache'
 module Services
   def self.publishing_api
     @publishing_api ||= GdsApi::PublishingApiV2.new(
-      Plek.find('publishing-api', external: true),
+      Plek.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
 
       # The cache is not threadsafe so using it can cause bulk imports to break

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -8,7 +8,7 @@ class SpecialRoutePublisher
 
   def take_ownership_of_search_routes
     publishing_api = GdsApi::PublishingApiV2.new(
-      Plek.new.find('publishing-api', external: true),
+      Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
     %w(/search /search.json /search/opensearch.xml).each do |path|


### PR DESCRIPTION
The environment changes have been made in Puppet

This reverts commit c2eccc436a6e36faf34a8c26c548617845b30c2d.

Trello card: https://trello.com/c/roOVfL9T/98-make-sure-emails-triggered-by-the-business-readiness-finder-will-continue-to-work