### PR TITLE
Do not close old page-traffic index

### DIFF
--- a/lib/govuk_index/page_traffic_loader.rb
+++ b/lib/govuk_index/page_traffic_loader.rb
@@ -29,7 +29,6 @@ module GovukIndex
       # The page traffic loader is is a daily process, so there
       # won't be a race condition
       index_group.switch_to(new_index)
-      old_index.close
     end
 
   private


### PR DESCRIPTION
AWS managed Elasticsearch doesn't allow the close API.  Leaving the
index open doesn't prevent it from being removed by the rummager:clean
task, so this isn't a problem.

---

[Trello card](https://trello.com/c/clepLUZZ/105-fetching-search-analytics-fails-with-an-error-about-the-password)