### PR TITLE
Keep rummager as the publishing_app for now

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -12,7 +12,7 @@ description: 'This is the information that has been published so far for your bu
 name: 'Find EU Exit guidance for your business'
 locale: en
 public_updated_at: '2018-11-23T09:00:00.000+00:00'
-publishing_app: search-api
+publishing_app: rummager
 rendering_app: finder-frontend
 details:
   beta: false

--- a/config/finders/advanced-search.yml
+++ b/config/finders/advanced-search.yml
@@ -6,7 +6,7 @@ document_type: search
 locale: en
 name: Advanced search
 phase: live
-publishing_app: search-api
+publishing_app: rummager
 rendering_app: finder-frontend
 schema_name: finder
 search_user_need_document_supertype: government

--- a/config/prepare-eu-exit.yml.erb
+++ b/config/prepare-eu-exit.yml.erb
@@ -15,7 +15,7 @@ description:
 name: <%= title %>
 locale: en
 public_updated_at: "<%= config[:timestamp] %>"
-publishing_app: search-api
+publishing_app: rummager
 rendering_app: finder-frontend
 details:
   beta: false

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -14,7 +14,7 @@ class SpecialRoutePublisher
     %w(/search /search.json /search/opensearch.xml).each do |path|
       publishing_api.put_path(
         path,
-        publishing_app: 'search-api',
+        publishing_app: 'rummager',
         override_existing: true
       )
     end
@@ -23,7 +23,7 @@ class SpecialRoutePublisher
   def publish(route)
     @publisher.publish(
       route.merge(
-        publishing_app: "search-api",
+        publishing_app: "rummager",
         format: "special_route",
         public_updated_at: Time.now.iso8601,
         update_type: "major",

--- a/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
+++ b/spec/unit/prepare_eu_exit_finder_publisher_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe PrepareEuExitFinderPublisher do
         "locale" => "en",
         "phase" => "live",
         "public_updated_at" => "2018-12-07T17:19:35+00:00",
-        "publishing_app" => "search-api",
+        "publishing_app" => "rummager",
         "rendering_app" => "finder-frontend",
         "routes" => [
           { "path" => "/prepare-eu-exit/seaside-fun", "type" => "exact" },


### PR DESCRIPTION
The paths are reserved by rummager in the publishing-api, we'll change
that (and this) when tearing down rummager.