### PR TITLE
Bump limit of default sidekiq queue to 8

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,9 +2,9 @@
 tag: search-api.publishing.service.gov.uk
 :concurrency: 5
 staging:
-  :concurrency:  16
+  :concurrency:  12
 production:
-  :concurrency:  16
+  :concurrency:  12
 :require: ./lib/rummager.rb
 :logfile: ./log/sidekiq.log
 :queues:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -12,4 +12,4 @@ production:
   - bulk
 :limits:
   bulk: 4
-  default: 4
+  default: 8


### PR DESCRIPTION
We've occasionally seen a build up of sidekiq jobs (in both search-api
and rummager).  I experimented by bumping the limit on the "default"
queue to 8 via the app console during one such spike: the jobs cleared
much faster than in rummager (which still had the limit of 4), and the
Elasticsearch search latency increased by maybe a couple of
milliseconds - it's hard to say because any increase is small enough
to be obscured by the natural variability of the metric.

These limits were added to solve a problem, but that problem occurred
with an almost totally different search architecture, so I think it's
worth experimenting with the limits a bit.  They could perhaps be
increased further, but let's see how this change performs for now.

---

Elasticsearch indexing rate (units are operations/minute), clear change showing when the number of workers went up:
<img width="1746" alt="Screen Shot 2019-04-05 at 12 19 42" src="https://user-images.githubusercontent.com/75235/55624215-27292280-579d-11e9-9862-2e2b04fc66aa.png">

Elasticsearch search latency (units are ms):
<img width="1744" alt="Screen Shot 2019-04-05 at 12 20 19" src="https://user-images.githubusercontent.com/75235/55624236-35773e80-579d-11e9-8fff-e8a1ab5a74f9.png">

search-api queue with limit 8:
<img width="1906" alt="Screen Shot 2019-04-05 at 12 17 17" src="https://user-images.githubusercontent.com/75235/55624092-cac60300-579c-11e9-9a82-fe9238fe2760.png">

rummager queue with limit 4:
<img width="1914" alt="Screen Shot 2019-04-05 at 12 17 52" src="https://user-images.githubusercontent.com/75235/55624117-dca7a600-579c-11e9-9dde-e182ff3342ec.png">
