### PR TITLE
Include facet_group in the patch_links call

### DIFF
--- a/lib/content_item_publisher/finder_presenter.rb
+++ b/lib/content_item_publisher/finder_presenter.rb
@@ -1,8 +1,10 @@
 module ContentItemPublisher
   class FinderPresenter < ContentItemPresenter
     def present_links
-      links = { "email_alert_signup" => email_alert_signup,
-               "parent" => content_item_parent }
+      links = {
+        "email_alert_signup" => email_alert_signup,
+        "parent" => content_item_parent
+      }.merge(facet_group)
 
       { content_id: content_id, links: links }
     end
@@ -14,6 +16,11 @@ module ContentItemPublisher
 
     def content_item_parent
       Array(content_item["parent"])
+    end
+
+    def facet_group
+      facet_group = content_item.dig("links", "facet_group")
+      facet_group ? { "facet_group" => facet_group } : {}
     end
   end
 end

--- a/spec/unit/content_item_publisher/finder_presenter_spec.rb
+++ b/spec/unit/content_item_publisher/finder_presenter_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe ContentItemPublisher::FinderPresenter do
                                                       "parent" => parent_links })
       end
 
+      it "includes facet_group in the links hash if present" do
+        facet_group_links = ['facet-group-uuid']
+        finder['links'] = { 'facet_group' => facet_group_links }
+        expect(instance.present_links[:links]).to include("facet_group" => facet_group_links)
+      end
+
       it "uses empty arrays to remove links" do
         finder_with_no_links = finder.except("parent").except("signup_content_id")
         presenter_with_empty_links = described_class.new(finder_with_no_links, timestamp)


### PR DESCRIPTION
When publishing a finder, we need the new `facet_group` links
to be included in the links sent to `patch_links` if it exists.

Discovered during https://trello.com/c/ovMEU0aL/283-end-to-end-testing-on-integration-of-new-links-based-approach-for-tagging 