### PR TITLE
Bump rack-logstasher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,10 +138,10 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-cache (1.9.0)
       rack (>= 0.4)
-    rack-logstasher (1.0.0)
+    rack-logstasher (1.0.1)
       logstash-event
       rack (~> 2.0)
     rack-protection (2.0.5)


### PR DESCRIPTION
This should make search-api logs look like other application logs in GOV.UK.  

Kibana logs should no longer have the `@fields` prefix in front of application fields like `duration` or `govuk_request_id`.

https://github.com/alphagov/rack-logstasher/blob/master/CHANGELOG.md#101