### PR TITLE
Catch and ignore BadRequest exceptions in best bet text analysis

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -183,11 +183,15 @@ module SearchIndices
     #
     # duplicated in document_preparer.rb
     def analyzed_best_bet_query(query)
-      analyzed_query = @client.indices.analyze(index: @index_name, text: query, analyzer: "best_bet_stemmed_match")
+      begin
+        analyzed_query = @client.indices.analyze(index: @index_name, text: query, analyzer: "best_bet_stemmed_match")
 
-      analyzed_query["tokens"].map { |token_info|
-        token_info["token"]
-      }.join(" ")
+        analyzed_query["tokens"].map { |token_info|
+          token_info["token"]
+        }.join(" ")
+      rescue Elasticsearch::Transport::Transport::Errors::BadRequest
+        ""
+      end
     end
 
     def delete(id)

--- a/lib/indexer/document_preparer.rb
+++ b/lib/indexer/document_preparer.rb
@@ -83,11 +83,15 @@ module Indexer
 
     # duplicated in index.rb
     def analyzed_best_bet_query(query)
-      analyzed_query = @client.indices.analyze(index: @index_name, text: query, analyzer: "best_bet_stemmed_match")
+      begin
+        analyzed_query = @client.indices.analyze(index: @index_name, text: query, analyzer: "best_bet_stemmed_match")
 
-      analyzed_query["tokens"].map { |token_info|
-        token_info["token"]
-      }.join(" ")
+        analyzed_query["tokens"].map { |token_info|
+          token_info["token"]
+        }.join(" ")
+      rescue Elasticsearch::Transport::Transport::Errors::BadRequest
+        ""
+      end
     end
 
     def add_self_to_organisations_links(doc_hash)


### PR DESCRIPTION
Some strings when passed to @client.indices.analyze, like "*" and "",
give a bad request error.  I don't fully understand what the
elasticsearch library is doing, because I can analyse such strings
manually with `curl` just fine, but here they're a problem.

Discard the exception and just say there are no best bets.  If there
is some more significant problem with the query, then it will probably
be flagged up when the actual search is performed.