### PR TITLE
Reject long queries

### DIFF
--- a/lib/parameter_parser/search_parameter_parser.rb
+++ b/lib/parameter_parser/search_parameter_parser.rb
@@ -11,6 +11,10 @@ class SearchParameterParser < BaseParameterParser
   # results in 5XX errors
   MAX_START = 900_000
 
+  # Reject queries over this length, because such queries are likely
+  # bots and have a negative effect on performance.
+  MAX_QUERY_LENGTH = 512
+
   def initialize(params, schema)
     @schema = schema
     process(params)
@@ -52,6 +56,10 @@ private
     # similar documents, but not both at the same time.
     if @parsed_params[:query] && @parsed_params[:similar_to]
       @errors << "Parameters 'q' and 'similar_to' cannot be used together"
+    end
+
+    if @parsed_params[:query] && @parsed_params[:query].length > MAX_QUERY_LENGTH
+      @errors << "Query exceeds the maximum allowed length"
     end
 
     unused_params = @params.keys - @used_params

--- a/spec/integration/search/batch_search_spec.rb
+++ b/spec/integration/search/batch_search_spec.rb
@@ -517,12 +517,6 @@ RSpec.describe 'BatchSearchTest' do
     expect_results_includes_ministry_of_magic(results, 1, 0)
   end
 
-  it "return 400 response for query term length too long" do
-    terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
-
-    expect { get build_get_url([{ q: terms }, { q: "Minstry of Magic" }]) }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest)
-  end
-
   it "will allow ten searches" do
     commit_ministry_of_magic_document
     searches = 10.times.map do

--- a/spec/integration/search/search_spec.rb
+++ b/spec/integration/search/search_spec.rb
@@ -589,12 +589,6 @@ RSpec.describe 'SearchTest' do
     })
   end
 
-  it "return 400 response for query term length too long" do
-    terms = 1025.times.map { ('a'..'z').to_a.sample(5).join }.join(' ')
-
-    expect { get "/search.json?q=#{terms}" }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest)
-  end
-
   private
 
   def first_result

--- a/spec/unit/parameter_parser/search_parameter_parser_spec.rb
+++ b/spec/unit/parameter_parser/search_parameter_parser_spec.rb
@@ -202,6 +202,17 @@ RSpec.describe SearchParameterParser do
     expect(p.parsed_params).to eq(expected_params(query: "search-term"))
   end
 
+  it "complains when the q parameter is too long" do
+    max_length = described_class::MAX_QUERY_LENGTH
+    long_query = "a" * max_length
+    too_long_query = "1234567890#{long_query}"
+    p = described_class.new({ "q" => [too_long_query] }, @schema)
+
+    expect(p.error).to eq(%{Query exceeds the maximum allowed length})
+    expect(p).not_to be_valid
+    expect(p.parsed_params).to eq(expected_params(query: too_long_query))
+  end
+
   it "complains about a repeated q parameter" do
     p = described_class.new({ "q" => %w(hello world) }, @schema)
 


### PR DESCRIPTION
We're seeing a few long, slow-running, queries which are clearly not
something entered by a human.  Stemming, synonyms, and other analyses
aren't free - so spending 1.3s executing a 1677-character query which
no human is looking at the result of seems like a waste of time and
effort.

We don't want to impact human users, so the new limit is quite high,
and there will be follow-up work in finder-frontend to suggest the
contact form when someone enters a long query.

---

[Trello card](https://trello.com/c/taQuHzDe/124-return-a-422-through-the-public-search-api-for-any-queries-512-characters)