### PR TITLE
Treat unmapped types as a missing value in sorting

### DIFF
--- a/lib/search/query_components/sort.rb
+++ b/lib/search/query_components/sort.rb
@@ -18,7 +18,18 @@ module QueryComponents
 
       field, order = search_params.order
 
-      [{ field => { order: order, missing: "_last" } }]
+      [
+        {
+          field => {
+            order: order,
+            missing: "_last",
+            # not all indices have all fields, so if the field is
+            # missing treat it as an integer (any type would work,
+            # really) with a missing value.
+            unmapped_type: "integer"
+          }
+       }
+      ]
     end
   end
 end

--- a/spec/unit/query_components/sort_spec_spec.rb
+++ b/spec/unit/query_components/sort_spec_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'SortTest' do
 
       result = builder.payload
 
-      expect(result).to eq([{ "public_timestamp" => { order: "asc", missing: "_last" } }])
+      expect(result).to eq([{ "public_timestamp" => { order: "asc", missing: "_last", unmapped_type: "integer" } }])
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe 'SortTest' do
 
       result = builder.payload
 
-      expect(result).to eq([{ "public_timestamp" => { order: "desc", missing: "_last" } }])
+      expect(result).to eq([{ "public_timestamp" => { order: "desc", missing: "_last", unmapped_type: "integer" } }])
     end
   end
 


### PR DESCRIPTION
Sorting on an unmapped field throws an error.  This is a problem
because our indices have different fields in their mappings.  So treat
an unmapped field as an integer, which will be given a missing value,
so the doc will then be caught by the `missing: "_last"`.

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html#_ignoring_unmapped_fields

---

[Trello card](https://trello.com/c/jz6vHhDv/120-look-into-no-mapping-found-for-x-errors)