### PR TITLE
Only generate 25,000 links per sitemap file

### DIFF
--- a/lib/sitemap/sitemap_cleanup.rb
+++ b/lib/sitemap/sitemap_cleanup.rb
@@ -19,7 +19,7 @@ private
   end
 
   def parse_sitemap_date(filename)
-    date_string = filename.match(/sitemap(?:_[0-9])?_([0-9T-]+)\.xml/)[1]
+    date_string = filename.match(/sitemap(?:_[0-9]+)?_([0-9T-]+)\.xml/)[1]
     Date.strptime(date_string, '%FT%H')
   end
 

--- a/lib/sitemap/sitemap_generator.rb
+++ b/lib/sitemap/sitemap_generator.rb
@@ -7,7 +7,7 @@ class SitemapGenerator
   end
 
   def self.sitemap_limit
-    50_000
+    25_000
   end
 
   def get_all_documents


### PR DESCRIPTION
We've seen issues with the sitemap generation task running out of
memory.  Not sure why this has started to happen over the last few
days, but a quick fix is to reduce the number of links per file - as
the entire xml file is generated in memory before being written to
disk.